### PR TITLE
fix: 移除话题引用中的 Tooltip 组件

### DIFF
--- a/src/renderer/src/pages/home/Markdown/TopicReference.tsx
+++ b/src/renderer/src/pages/home/Markdown/TopicReference.tsx
@@ -1,7 +1,7 @@
 import { TopicManager } from '@renderer/hooks/useTopic'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import { Message } from '@renderer/types'
-import { Popover, Tooltip } from 'antd'
+import { Popover } from 'antd'
 import { FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -65,9 +65,7 @@ const TopicReference: FC<TopicReferenceProps> = ({ topicName, topicId }) => {
           fetchTopicMessages()
         }
       }}>
-      <Tooltip title={`Topic ID: ${topicId}`} mouseEnterDelay={0.8}>
-        <TopicTag onClick={handleNavigateToTopic}>{topicName}</TopicTag>
-      </Tooltip>
+      <TopicTag onClick={handleNavigateToTopic}>{topicName}</TopicTag>
     </Popover>
   )
 }


### PR DESCRIPTION
This pull request includes changes to the `TopicReference` component in the `src/renderer/src/pages/home/Markdown/TopicReference.tsx` file. The main focus of these changes is to remove the unused `Tooltip` import and its associated usage within the component.

Changes to `TopicReference` component:

* Removed the import of `Tooltip` from `antd` as it was not being used elsewhere in the component.
* Removed the `Tooltip` wrapper around the `TopicTag` element, which was displaying the `topicId` on mouse hover.